### PR TITLE
dockerfile for code-engine

### DIFF
--- a/backend/Dockerfile_CodeEngine
+++ b/backend/Dockerfile_CodeEngine
@@ -1,0 +1,20 @@
+FROM registry.access.redhat.com/ubi8
+
+WORKDIR /app
+
+COPY Pipfile* /app/
+
+## NOTE - rhel enforces user container permissions stronger ##
+USER root
+RUN yum -y install python3
+RUN yum -y install python3-pip wget
+
+# RUN python3 -m pip install --upgrade pip \
+#  && python3 -m pip install --upgrade pipenv \
+#  && pipenv install --system --deploy
+
+USER 1001
+
+COPY . /app
+ENV FLASK_APP=server/__init__.py
+CMD ["python3", "manage.py", "start", "0.0.0.0:3000"]


### PR DESCRIPTION
first try for new build on code-engine
(full file created following error)
```
$  ce buildrun get --name sh-buildrun-cc2020-09
===> dockerfile not correctly:
Project 'sh-proj-01' and all its contents will be automatically deleted 4 days from now.
Getting build run 'sh-buildrun-cc2020-09'...
OK
Name:          sh-buildrun-cc2020-09
ID:            f0a40dd7-0474-4002-b6bf-7e9319fd4efc
Project Name:  sh-proj-01
Project ID:    30c7c58a-bd85-46a3-b096-4c5a5a99af31
Age:           3m32s
Created:       2020-10-19 21:39:51 +0200 CEST
Status:
  Reason:      "step-step-build-and-push" exited with code 1 (image: "icr.io/obs/codeengine/kaniko/executor@sha256:e36c9fa99279217c4bb8ee172819b441c3ca8ef946dc0e28b21721eefb2ba70a"); 
  for logs run: kubectl -n 16hpqn7r3d6 logs sh-buildrun-cc2020-09-v77px-pod-z5dcr -c step-step-build-and-push
  Registered:  False
Instances:
  Name                                   Running  Status  Restarts  Age
  sh-buildrun-cc2020-09-v77px-pod-z5dcr  0/4      Failed  0         3m34s
$  kubectl -n 16hpqn7r3d6 logs sh-buildrun-cc2020-09-v77px-pod-z5dcr -c step-step-build-and-push
INFO[0002] Retrieving image manifest registry.access.redhat.com/ubi8
INFO[0002] Retrieving image registry.access.redhat.com/ubi8
INFO[0003] Retrieving image manifest registry.access.redhat.com/ubi8
INFO[0003] Retrieving image registry.access.redhat.com/ubi8
INFO[0003] Built cross stage deps: map[]
INFO[0003] Retrieving image manifest registry.access.redhat.com/ubi8
INFO[0003] Retrieving image registry.access.redhat.com/ubi8
INFO[0008] Retrieving image manifest registry.access.redhat.com/ubi8
INFO[0008] Retrieving image registry.access.redhat.com/ubi8
INFO[0008] Executing 0 build triggers
INFO[0008] Unpacking rootfs as cmd COPY Pipfile* /app/ requires it.
INFO[0018] WORKDIR /app
INFO[0018] cmd: workdir
INFO[0018] Changed working directory to /app
INFO[0018] Creating directory /app
INFO[0018] Taking snapshot of files...
INFO[0018] Resolving srcs [Pipfile*]...
INFO[0018] COPY Pipfile* /app/
INFO[0018] Resolving srcs [Pipfile*]...
INFO[0018] Taking snapshot of files...
INFO[0018] USER root
INFO[0018] cmd: USER
INFO[0018] RUN yum -y install python3
INFO[0018] Taking snapshot of full filesystem...
INFO[0019] cmd: /bin/sh
INFO[0019] args: [-c yum -y install python3]
INFO[0019] util.Lookup returned: &{Uid:0 Gid:1 Username:root Name: HomeDir:/tekton/home}
INFO[0019] performing slow lookup of group ids for root
INFO[0019] Running: [/bin/sh -c yum -y install python3]
Updating Subscription Management repositories.
Unable to read consumer identity
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
Red Hat Universal Base Image 8 (RPMs) - BaseOS  5.6 MB/s | 769 kB     00:00
Red Hat Universal Base Image 8 (RPMs) - AppStre  23 MB/s | 4.0 MB     00:00
Red Hat Universal Base Image 8 (RPMs) - CodeRea 101 kB/s |  13 kB     00:00
Dependencies resolved.
==========================================================================================
 Package               Arch    Version                              Repository        Size
==========================================================================================
Installing:
 python36              x86_64  3.6.8-2.module+el8.1.0+3334+5cb623d7 ubi-8-appstream   19 k
Installing dependencies:
 platform-python-pip   noarch  9.0.3-16.el8                         ubi-8-baseos     1.8 M
 python3-pip           noarch  9.0.3-16.el8                         ubi-8-appstream   20 k
 python3-setuptools    noarch  39.2.0-5.el8                         ubi-8-baseos     163 k
Enabling module streams:
 python36                      3.6
Transaction Summary
==========================================================================================
Install  4 Packages
Total download size: 2.0 M
Installed size: 7.8 M
Downloading Packages:
(1/4): python36-3.6.8-2.module+el8.1.0+3334+5cb 351 kB/s |  19 kB     00:00
(2/4): python3-pip-9.0.3-16.el8.noarch.rpm      4.8 MB/s |  20 kB     00:00
(3/4): python3-setuptools-39.2.0-5.el8.noarch.r 2.6 MB/s | 163 kB     00:00
(4/4): platform-python-pip-9.0.3-16.el8.noarch.  17 MB/s | 1.8 MB     00:00
--------------------------------------------------------------------------------
Total                                            17 MB/s | 2.0 MB     00:00
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1
  Installing       : python3-setuptools-39.2.0-5.el8.noarch                 1/4
  Installing       : platform-python-pip-9.0.3-16.el8.noarch                2/4
  Installing       : python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.x86_64   3/4
  Running scriptlet: python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.x86_64   3/4
  Installing       : python3-pip-9.0.3-16.el8.noarch                        4/4
  Running scriptlet: python3-pip-9.0.3-16.el8.noarch                        4/4
  Verifying        : platform-python-pip-9.0.3-16.el8.noarch                1/4
  Verifying        : python3-setuptools-39.2.0-5.el8.noarch                 2/4
  Verifying        : python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.x86_64   3/4
  Verifying        : python3-pip-9.0.3-16.el8.noarch                        4/4
Installed products updated.
Installed:
  platform-python-pip-9.0.3-16.el8.noarch
  python3-pip-9.0.3-16.el8.noarch
  python3-setuptools-39.2.0-5.el8.noarch
  python36-3.6.8-2.module+el8.1.0+3334+5cb623d7.x86_64
Complete!
INFO[0024] Taking snapshot of full filesystem...
INFO[0026] RUN yum -y install python3-pip wget
INFO[0026] cmd: /bin/sh
INFO[0026] args: [-c yum -y install python3-pip wget]
INFO[0026] util.Lookup returned: &{Uid:0 Gid:1 Username:root Name: HomeDir:/tekton/home}
INFO[0026] performing slow lookup of group ids for root
INFO[0026] Running: [/bin/sh -c yum -y install python3-pip wget]
Updating Subscription Management repositories.
Unable to read consumer identity
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
Last metadata expiration check: 0:00:05 ago on Mon Oct 19 19:40:38 2020.
Package python3-pip-9.0.3-16.el8.noarch is already installed.
Dependencies resolved.
================================================================================
 Package     Architecture  Version                 Repository              Size
================================================================================
Installing:
 wget        x86_64        1.19.5-8.el8_1.1        ubi-8-appstream        735 k
Transaction Summary
================================================================================
Install  1 Package
Total download size: 735 k
Installed size: 2.9 M
Downloading Packages:
wget-1.19.5-8.el8_1.1.x86_64.rpm                9.4 MB/s | 735 kB     00:00
--------------------------------------------------------------------------------
Total                                           8.7 MB/s | 735 kB     00:00
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1
  Installing       : wget-1.19.5-8.el8_1.1.x86_64                           1/1
  Running scriptlet: wget-1.19.5-8.el8_1.1.x86_64                           1/1
  Verifying        : wget-1.19.5-8.el8_1.1.x86_64                           1/1
Installed products updated.
Installed:
  wget-1.19.5-8.el8_1.1.x86_64
Complete!
INFO[0029] Taking snapshot of full filesystem...
INFO[0030] RUN python3 -m pip install --upgrade pip   && python3 -m pip install --upgrade pipenv   && pipenv install --system --deploy
INFO[0030] cmd: /bin/sh
INFO[0030] args: [-c python3 -m pip install --upgrade pip   && python3 -m pip install --upgrade pipenv   && pipenv install --system --deploy]
INFO[0030] util.Lookup returned: &{Uid:0 Gid:1 Username:root Name: HomeDir:/tekton/home}
INFO[0030] performing slow lookup of group ids for root
INFO[0030] Running: [/bin/sh -c python3 -m pip install --upgrade pip   && python3 -m pip install --upgrade pipenv   && pipenv install --system --deploy]
WARNING: Running pip install with root privileges is generally not a good idea. Try `__main__.py install --user` instead.
Collecting pip
  Downloading https://files.pythonhosted.org/packages/cb/28/91f26bd088ce8e22169032100d4260614fc3da435025ff389ef1d396a433/pip-20.2.4-py2.py3-none-any.whl (1.5MB)
Installing collected packages: pip
Successfully installed pip-20.2.4
Collecting pipenv
  Downloading pipenv-2020.8.13-py2.py3-none-any.whl (3.9 MB)
Requirement already satisfied, skipping upgrade: pip>=18.0 in /usr/local/lib/python3.6/site-packages (from pipenv) (20.2.4)
Collecting certifi
  Downloading certifi-2020.6.20-py2.py3-none-any.whl (156 kB)
Collecting virtualenv-clone>=0.2.5
  Downloading virtualenv_clone-0.5.4-py2.py3-none-any.whl (6.6 kB)
Collecting virtualenv
  Downloading virtualenv-20.0.35-py2.py3-none-any.whl (4.9 MB)
Requirement already satisfied, skipping upgrade: setuptools>=36.2.1 in /usr/lib/python3.6/site-packages (from pipenv) (39.2.0)
Collecting filelock<4,>=3.0.0
  Downloading filelock-3.0.12-py3-none-any.whl (7.6 kB)
Collecting appdirs<2,>=1.4.3
  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
Collecting importlib-resources>=1.0; python_version < "3.7"
  Downloading importlib_resources-3.0.0-py2.py3-none-any.whl (23 kB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.1-py2.py3-none-any.whl (335 kB)
Requirement already satisfied, skipping upgrade: six<2,>=1.9.0 in /usr/lib/python3.6/site-packages (from virtualenv->pipenv) (1.11.0)
Collecting importlib-metadata<3,>=0.12; python_version < "3.8"
  Downloading importlib_metadata-2.0.0-py2.py3-none-any.whl (31 kB)
Collecting zipp>=0.4; python_version < "3.8"
  Downloading zipp-3.3.1-py3-none-any.whl (5.3 kB)
Installing collected packages: certifi, virtualenv-clone, filelock, appdirs, zipp, importlib-resources, distlib, importlib-metadata, virtualenv, pipenv
Successfully installed appdirs-1.4.4 certifi-2020.6.20 distlib-0.3.1 filelock-3.0.12 importlib-metadata-2.0.0 importlib-resources-3.0.0 pipenv-2020.8.13 virtualenv-20.0.35 virtualenv-clone-0.5.4 zipp-3.3.1
[PipenvOptionsError]:   File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/decorators.py", line 73, in new_func
[PipenvOptionsError]:       return ctx.invoke(f, obj, *args, **kwargs)
[PipenvOptionsError]:   File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 610, in invoke
[PipenvOptionsError]:       return callback(*args, **kwargs)
[PipenvOptionsError]:   File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/decorators.py", line 21, in new_func
[PipenvOptionsError]:       return f(get_current_context(), *args, **kwargs)
[PipenvOptionsError]:   File "/usr/local/lib/python3.6/site-packages/pipenv/cli/command.py", line 252, in install
[PipenvOptionsError]:       site_packages=state.site_packages
[PipenvOptionsError]:   File "/usr/local/lib/python3.6/site-packages/pipenv/core.py", line 2063, in do_install
[PipenvOptionsError]:       keep_outdated=keep_outdated
[PipenvOptionsError]:   File "/usr/local/lib/python3.6/site-packages/pipenv/core.py", line 1289, in do_init
[PipenvOptionsError]:       "--system is intended to be used for Pipfile installation,
ERROR:: --system is intended to be used for Pipfile installation, not installation of specific packages. Aborting.
See also: --deploy flag.
error building image: error building stage: failed to execute command: waiting for process to exit: exit status 1
```